### PR TITLE
Fixed the JS selection of page description as title if the og:title is missing

### DIFF
--- a/public/js/super-web-share-public.js
+++ b/public/js/super-web-share-public.js
@@ -66,8 +66,8 @@ const getPageMeta = () =>{
 
     if (document.querySelector('meta[property="og:title"]') != null) {
         mData.meta_title = document.querySelector('meta[property="og:title"]').content;
-    } else if (document.querySelector('meta[property="description"]') != null) {
-        mData.meta_title = document.querySelector('meta[property="description"]').content;
+    } else if (document.querySelector('meta[property="twitter:title"]') != null) {
+        mData.meta_title =  document.querySelector('meta[property="twitter:title"]').content;
     } else {
         mData.meta_title = document.title;
     }


### PR DESCRIPTION
- Slight change to the JS to select the Twitter title on the page if the Open graph title is missing.