### PR TITLE
Disable native share on desktop to forcefully show the fallback

### DIFF
--- a/admin/class-super-web-share-admin.php
+++ b/admin/class-super-web-share-admin.php
@@ -606,63 +606,72 @@ add_action( 'admin_init', 'superwebshare_register_settings_floating' );
 function superwebshare_register_settings_fallback(){
 	// Register Setting
 	register_setting( 
-		'superwebshare_settings_fallback_group', 					// Group name
-		'superwebshare_fallback_settings', 							// Setting name = html form <input> name on settings form
-		'superwebshare_validater_and_sanitizer_fallback'			// Input sanitizer
+		'superwebshare_settings_fallback_group', 		// Group name
+		'superwebshare_fallback_settings', 			// Setting name = html form <input> name on settings form
+		'superwebshare_validater_and_sanitizer_fallback'	// Input sanitizer
 	);
 
 	// Floating Button Settings
 	add_settings_section(
-        'superwebshare_fallback_settings_section',					// ID
-        __('Fallback Settings', 'super-web-share'),					// Title
-        '__return_false',											// Callback Function
-        'superwebshare_fallback_settings_section'					// Page slug
+        'superwebshare_fallback_settings_section',				// ID
+        __('Fallback Settings', 'super-web-share'),				// Title
+        '__return_false',							// Callback Function
+        'superwebshare_fallback_settings_section'				// Page slug
 	);
 
 	// Description
 	add_settings_field(
-		'superwebshare_inline_description_share',					// ID
-		__('', 'super-web-share'),									// Title
-		'superwebshare_fallback_description_cb',					// CB
-		'superwebshare_fallback_settings_section',					// Page slug
-		'superwebshare_fallback_settings_section'					// Settings Section ID
+		'superwebshare_inline_description_share',			// ID
+		__('', 'super-web-share'),					// Title
+		'superwebshare_fallback_description_cb',			// CB
+		'superwebshare_fallback_settings_section',			// Page slug
+		'superwebshare_fallback_settings_section'			// Settings Section ID
 	);
 
 	// Since 2.0
 	add_settings_field(
-		'superwebshare_fallback_enable',							// ID
-		__('Show fallback share buttons', 'super-web-share'),	// Title
-		'superwebshare_fallback_enable_cb',							// CB
-		'superwebshare_fallback_settings_section',					// Page slug
-		'superwebshare_fallback_settings_section'					// Settings Section ID
+		'superwebshare_fallback_enable',				// ID
+		__('Show fallback share buttons', 'super-web-share'),		// Title
+		'superwebshare_fallback_enable_cb',				// CB
+		'superwebshare_fallback_settings_section',			// Page slug
+		'superwebshare_fallback_settings_section'			// Settings Section ID
 	);
 
 	//Since 2.1  for fallback modal color
 	add_settings_field(
-		'fallback_modal_background',								// ID
+		'fallback_modal_background',					// ID
 		__('Background color for fallback', 'super-web-share'),		// Title
-		'superwebshare_fallback_modal_background_color_cb',			// CB
-		'superwebshare_fallback_settings_section',					// Page slug
-		'superwebshare_fallback_settings_section'					// Settings Section ID
+		'superwebshare_fallback_modal_background_color_cb',		// CB
+		'superwebshare_fallback_settings_section',			// Page slug
+		'superwebshare_fallback_settings_section'			// Settings Section ID
 	);
 
 	//Since 2.1 for layout selection for fallback
 	add_settings_field(
-		'superwebshare_fallback_modal_layout',						// ID
-		__('Fallback layout', 'super-web-share'),					// Title
-		'superwebshare_fallback_modal_layout_cb',					// CB
-		'superwebshare_fallback_settings_section',					// Page slug
-		'superwebshare_fallback_settings_section'					// Settings Section ID
+		'superwebshare_fallback_modal_layout',				// ID
+		__('Fallback layout', 'super-web-share'),			// Title
+		'superwebshare_fallback_modal_layout_cb',			// CB
+		'superwebshare_fallback_settings_section',			// Page slug
+		'superwebshare_fallback_settings_section'			// Settings Section ID
 	);
 	
 	//Since 2.4 - Color settings for the Fallback text
 	add_settings_field(
-		'superwebshare_fallback_text_color',						// ID
-		__('Fallback text color', 'super-web-share'),					// Title
-		'superwebshare_fallback_text_color_cb',						// CB
-		'superwebshare_fallback_settings_section',					// Page slug
-		'superwebshare_fallback_settings_section'					// Settings Section ID
-	);	
+		'superwebshare_fallback_text_color',				// ID
+		__('Fallback text color', 'super-web-share'),			// Title
+		'superwebshare_fallback_text_color_cb',				// CB
+		'superwebshare_fallback_settings_section',			// Page slug
+		'superwebshare_fallback_settings_section'			// Settings Section ID
+	);
+	
+	//Since 2.4 - Disable native share on desktop to forcefully show the fallback
+	add_settings_field(
+		'superwebshare_fallback_show_fallback',								// ID
+		__('Do you want to show the fallback modal within the desktop devices?', 'super-web-share'),	// Title
+		'superwebshare_fallback_show_fallback_cb',							// CB
+		'superwebshare_fallback_settings_section',							// Page slug
+		'superwebshare_fallback_settings_section'							// Settings Section ID
+	);
 
 	/**
 	 * Since 2.3 for twitter via url parameter
@@ -670,11 +679,11 @@ function superwebshare_register_settings_fallback(){
 	 */
 
 	add_settings_field(
-		'fallback_twitter_via',										// ID
-		__('Twitter username', 'super-web-share'),					// Title
-		'fallback_twitter_via_cb',									// CB
-		'superwebshare_fallback_settings_section',					// Page slug
-		'superwebshare_fallback_settings_section'					// Settings Section ID
+		'fallback_twitter_via',						// ID
+		__('Twitter username', 'super-web-share'),			// Title
+		'fallback_twitter_via_cb',					// CB
+		'superwebshare_fallback_settings_section',			// Page slug
+		'superwebshare_fallback_settings_section'			// Settings Section ID
 	);
 
 }
@@ -829,7 +838,8 @@ function superwebshare_settings_default( $name ){
 			'fallback_modal_background' 		=> '#BD3854',		// default color for fallback modal - 2.1
 			'fallback_layout'			=> '1',			// fallback layout color - 2.1
 			'fallback_twitter_via'			=> '',			// default value none
-			'fallback_text_color'			=> '#fff'		// default color #fff
+			'fallback_text_color'			=> '#fff',		// default color #fff
+			'fallback_show_in_desktop'		=> 'disable'		// default value as disable to trigger based on API support - 2.4
 		),
 		"appearance" => array(
 			'superwebshare_appearance_button_icon' 	=> 'share-icon-1', 	// default value "share-icon-1"

--- a/admin/partials/super-web-share-admin-display.php
+++ b/admin/partials/super-web-share-admin-display.php
@@ -294,6 +294,22 @@ function superwebshare_fallback_text_color_cb(){
 }
 
 /**
+ *  Disable native share on desktop to forcefully show the fallback
+ *
+ * @since 2.4
+ */ 
+function superwebshare_fallback_show_fallback_cb(){
+	$settings_fallback = superwebshare_get_settings_fallback();
+	$saved = isset( $settings_fallback[ 'fallback_show_in_desktop' ] ) ? esc_html( $settings_fallback[ 'fallback_show_in_desktop' ] ) : "disable";
+	superwebshare_input_toggle( 'superwebshare_fallback_settings[fallback_show_in_desktop]', 'enable',  $saved );
+	?>
+		<p class="description">
+			<?php _e('This setting does not apply to Microsoft Edge Browser as the sharing dialog box has social media links same as our fallback.', 'super-web-share'); ?>
+		</p>
+	<?php
+}
+
+/**
  * Fallback twitter Via parameter value field
  * @since 2.3
  */ 

--- a/public/js/super-web-share-public.js
+++ b/public/js/super-web-share-public.js
@@ -35,8 +35,20 @@ function hasPermission() {
       console.log('SuperWebShare: Your browser does not seems to support SuperWebShare, as the browser is incompatible');
   }
 }
+const fallbackForcefullyShowDesktop = () =>{
+    // This settings not applicable for MS Edge browser.
+    if( window.superWebShareFallback.fallback_show_in_desktop === 'enable' ){
+
+        let isIEedge = window.navigator.userAgent.indexOf("Edg") > -1;
+        let regexp = /android|iphone|kindle|ipad|webos|ipod/i;
+        let isDesktop = ! regexp.test( window.navigator.userAgent )
+        return isDesktop && !isIEedge
+    }else{
+        return false;
+    }
+}
 async function SuperWebSharefn(Title, URL, Description) {
-  if (typeof navigator.share === 'undefined' || !navigator.share) {
+  if (typeof navigator.share === 'undefined' || !navigator.share || fallbackForcefullyShowDesktop()) {
       modal();
   } else if (window.location.protocol != 'https:') {
       console.log('SuperWebShare: Seems like the website is not served fully via https://. As for supporting SuperWebShare the website should be served fully via https://');


### PR DESCRIPTION
- To fix the issue with native sharing showing on desktop devices.
- Excluded the Microsoft Edge at this moment, as ME shows the fallback same as like SuperWebShare