### PR TITLE
Fixed the error WP_Plugins_List_Table occurs when the plugin is activ…

### DIFF
--- a/admin/functions-super-web-share-admin.php
+++ b/admin/functions-super-web-share-admin.php
@@ -287,10 +287,10 @@ add_filter( 'update_footer', 'superwebshare_footer_version', 11 );
  *
  * Will redirect to SuperWebShare settings page when plugin is activated.
  * Will not redirect if multiple plugins are activated at the same time.
- * Will not redirect when activated network wide on multisite. Network admins know their way.
+ * Will not redirect when activated network-wide on multisite. Network admins know their way.
  *
  * @param  mixed $plugin plugin object.
- * @param  mixed $network_wide the flag for network wide.
+ * @param  mixed $network_wide the flag for network-wide.
  * @return void|boolean
  *
  * @since 1.3
@@ -305,16 +305,20 @@ function superwebshare_activation_redirect( $plugin, $network_wide ) {
 	 *
 	 * @link https://core.trac.wordpress.org/browser/tags/4.9.8/src/wp-admin/plugins.php#L15
 	 */
-	$wp_list_table_instance = new WP_Plugins_List_Table();
-	$current_action         = $wp_list_table_instance->current_action();
-	// When only one plugin is activated, the current_action() method will return activate.
-	if ( 'activate' !== $current_action ) {
-		return false;
-	}
-	// Redirect to Super Web Share settings page.
-	$url = admin_url( 'admin.php?page=superwebshare' );
-	wp_safe_redirect( $url );
-	exit();
+	 if( class_exists( "WP_Plugins_List_Table" ) ){
+
+		$wp_list_table_instance = new WP_Plugins_List_Table();
+		$current_action         = $wp_list_table_instance->current_action();
+		// When only one plugin is activated, the current_action() method will return activate.
+		if ( 'activate' !== $current_action ) {
+			return false;
+		}
+		// Redirect to Super Web Share settings page.
+		$url = admin_url( 'admin.php?page=superwebshare' );
+		wp_safe_redirect( $url );
+		exit();
+
+	 }
 }
 add_action( 'activated_plugin', 'superwebshare_activation_redirect', PHP_INT_MAX, 2 );
 


### PR DESCRIPTION
The error WP_Plugins_List_Table shows from WP 6.5 to 6.5.3 due to this: https://core.trac.wordpress.org/ticket/61331. However, this error won't occur from WP version 6.5.4 as the WP team reverted it. So, adding a condition to check whether the class exists to redirect to the admin URL if it gets introduced again.

## Pull Request Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [x] The commit message follows our guidelines:  https://github.com/superwebshare/super-web-share/blob/trunk/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

*

## Description
An explanation of what is done in this PR

*

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
